### PR TITLE
Täsmennetty tehtävien 22 ja 23 syötekuvaus

### DIFF
--- a/source/part1.html.erb
+++ b/source/part1.html.erb
@@ -2591,7 +2591,7 @@ System.out.println(tulos);
 <% partial 'partials/exercise', locals: { name: 'Kahden luvun keskiarvo', model_solution: '50227' } do %>
 
   <p>
-    Kirjoita ohjelma, joka kysyy käyttäjältä kahta lukua ja tulostaa lukujen keskiarvon.
+    Kirjoita ohjelma, joka kysyy käyttäjältä kahta kokonaislukua ja tulostaa lukujen keskiarvon.
   </p>
 
   <% partial 'partials/sample_output' do %>
@@ -2608,7 +2608,7 @@ System.out.println(tulos);
 <% partial 'partials/exercise', locals: { name: 'Kolmen luvun keskiarvo', model_solution: '50228' } do %>
 
   <p>
-    Kirjoita ohjelma, joka kysyy käyttäjältä kolme lukua ja tulostaa lukujen keskiarvon.
+    Kirjoita ohjelma, joka kysyy käyttäjältä kolme kokonaislukua ja tulostaa lukujen keskiarvon.
   </p>
 
   <% partial 'partials/sample_output' do %>


### PR DESCRIPTION
Tehtävät olettavat saavansa kokonaislukuja, ja ainakin tehtävässä 22 eivät testit eivät hyväksyneet doublemuotoista syötettä. Muuttamalla sana luku muotoon kokonaisluku, tällaiset vältettäneen jatkossa.