### PR TITLE
Typo fix

### DIFF
--- a/source/part2.html.erb
+++ b/source/part2.html.erb
@@ -362,7 +362,7 @@ if (<em>lauseke</em>) {
   <% partial 'partials/sample_output' do %>
     <font color="red">1</font>
     <font color="red">1</font>
-    Luku 1 on yhtä suuri kuin luku 4.
+    Luku 1 on yhtä suuri kuin luku 1.
   <% end %>
 
 <% end %>


### PR DESCRIPTION
Tehtävässä neljä esimerkkitulostus väittää "Luku 1 on yhtä suuri kuin luku 4.", muutettu
-> "Luku 1 on yhtä suuri kuin luku 1."