### PR TITLE
Typo 05_4.3 - 780 = 870

### DIFF
--- a/source/part5.html.erb
+++ b/source/part5.html.erb
@@ -1721,7 +1721,7 @@ public void vanhene(int vuodet) {
 
 
 <% partial 'partials/sample_output' do %>
-  Muhammad ibn Musa al-Khwarizmi, syntynyt 1.1.870
+  Muhammad ibn Musa al-Khwarizmi, syntynyt 1.1.780
   Blaise Pascal, syntynyt 19.6.1623
 <% end %>
 


### PR DESCRIPTION
Olioon muhammad asetetaan syntymävuosi 780, mutta esimerkkitulostuksessa tulostuu 870. Wikipedian mukaan 780 on oikea syntymävuosi.