### PR TITLE
Minor text fixes

### DIFF
--- a/source/part8.html.erb
+++ b/source/part8.html.erb
@@ -2429,7 +2429,7 @@ System.out.println(palautaKoko(nimet));
 
 <% partial 'partials/code_highlight' do %>
 Map&lt;String, String&gt; kaannokset = new HashMap&lt;&gt;();
-kaannokset.put("gambatte", "tsemppiä");
+kaannokset.put("ganbatte", "tsemppiä");
 kaannokset.put("hai", "kyllä");
 <% end %>
 
@@ -2439,7 +2439,7 @@ kaannokset.put("hai", "kyllä");
 
 <% partial 'partials/code_highlight' do %>
 Map&lt;String, String&gt; kaannokset = new HashMap&lt;&gt;();
-kaannokset.put("gambatte", "tsemppiä");
+kaannokset.put("ganbatte", "tsemppiä");
 kaannokset.put("hai", "kyllä");
 
 for (String avain: kaannokset.keySet()) {
@@ -2448,7 +2448,7 @@ for (String avain: kaannokset.keySet()) {
 <% end %>
 
 <% partial 'partials/sample_output' do %>
-gambatte: tsemppiä
+ganbatte: tsemppiä
 hai: kyllä
 <% end %>
 
@@ -2559,7 +2559,7 @@ System.out.println(palautaKoko(nimet));
 
 <% partial 'partials/code_highlight' do %>
 Map&lt;String, String&gt; kaannokset = new HashMap&lt;&gt;();
-kaannokset.put("gambatte", "tsemppiä");
+kaannokset.put("ganbatte", "tsemppiä");
 kaannokset.put("hai", "kyllä");
 
 Set&lt;String&gt; avaimet = kaannokset.keySet();
@@ -2581,7 +2581,7 @@ for (String arvo: arvot) {
 
 <% partial 'partials/sample_output' do %>
 Avaimet:
-gambatte
+ganbatte
 hai
 
 Arvot:
@@ -3124,7 +3124,7 @@ kauppa.asioi("Pekka");
   }<% end %>
 
 <p>
-  Metodille <code>tulostaMerkit</code> voi antaa minkä tahansa <code>CharSequence</code>-rajapinnan toteuttavan olion. Näitä on muunmuassa <code>String</code> ja merkkijonojen rakentamisessa usein Stringiä tehokkaampi <code>StringBuilder</code>. Metodi <code>tulostaMerkit</code> tulostaa annetun olion jokaisen merkin omalle rivilleen.
+  Metodille <code>tulostaMerkit</code> voi antaa minkä tahansa <code>CharSequence</code>-rajapinnan toteuttavan olion. Näitä ovat muun muassa <code>String</code> ja merkkijonojen rakentamisessa usein Stringiä tehokkaampi <code>StringBuilder</code>. Metodi <code>tulostaMerkit</code> tulostaa annetun olion jokaisen merkin omalle rivilleen.
 </p>
 
 <% partial 'partials/code_highlight' do %>


### PR DESCRIPTION
Huom: "tsemppiä" lausutaan kylläkin japaniksi "gambatte" mutta kirjoitetaan "ganbatte"