### PR TITLE
Korjattu tehtävien 11.1 ja 11.2 kirjoitusvirheet.

### DIFF
--- a/source/part11.html.erb
+++ b/source/part11.html.erb
@@ -273,7 +273,7 @@
       <code>public T otaPiilosta()</code> ottaa piilosta luokan tyyppiparametrin mukaisen olion. Mikäli piilossa ei ole mitään, palautetaan <code>null</code>. Metodin kutsuminen palauttaa piilossa olevan olion ja poistaa olion piilosta.
     </li>
     <li>
-      <code>public void onkoPiilossa()</code> palauttaa arvon <code>true</code> mikäli piilossa on olio. Mikäli piilossa ei ole oliota, palauttaa arvon <code>false</code>.
+      <code>public boolean onkoPiilossa()</code> palauttaa arvon <code>true</code> mikäli piilossa on olio. Mikäli piilossa ei ole oliota, palauttaa arvon <code>false</code>.
     </li>
   </ul>
 
@@ -342,7 +342,7 @@
       <code>public T otaPutkesta()</code> ottaa putkesta siellä pisimpään olleen arvon. Mikäli putkessa ei ole mitään, palautetaan <code>null</code>. Metodin kutsuminen palauttaa putkessa pisimpään olleen olion ja poistaa sen putkesta.
     </li>
     <li>
-      <code>public void onkoPutkessa()</code> palauttaa arvon <code>true</code> mikäli putkessa on arvoja. Mikäli putki on tyhjä, palauttaa arvon <code>false</code>.
+      <code>public boolean onkoPutkessa()</code> palauttaa arvon <code>true</code> mikäli putkessa on arvoja. Mikäli putki on tyhjä, palauttaa arvon <code>false</code>.
     </li>
   </ul>
 


### PR DESCRIPTION
Osan 11 tehtävissä 1 ja 2 kirotusvirhe. Opiskelijaa ohjeistetaan luomaan metodit joiden rungon määrittelyssä palautusarvon tyypiksi on merkitty void. Kuitenkin metodien tulee palauttaa boolean arvo. Korjattu metodien rungon palautusarvoksi boolean.